### PR TITLE
Add "Consolidate Files to Single Folder" Feature

### DIFF
--- a/ContextCreator/MainWindow.xaml
+++ b/ContextCreator/MainWindow.xaml
@@ -37,6 +37,7 @@
                 <MenuItem Header="_Export Context..." Command="{Binding ExportContextCommand}" InputGestureText="Ctrl+E"/>
                 <Separator/>
                 <MenuItem Header="Create _Folder with Current Setup..." Command="{Binding CreateFolderWithSetupCommand}" InputGestureText="Ctrl+N"/>
+                <MenuItem Header="Consolidate _Files to Single Folder..." Command="{Binding ConsolidateFilesCommand}" InputGestureText="Ctrl+F"/>
                 <Separator/>
                 <MenuItem Header="E_xit" Click="ExitMenuItem_Click" InputGestureText="Alt+F4"/>
             </MenuItem>
@@ -60,7 +61,7 @@
                 </MenuItem>
             </MenuItem>
             <MenuItem Header="_Tools">
-                <MenuItem Header="_Content Filter..." Click="ContentFilterMenuItem_Click" InputGestureText="Ctrl+F"/>
+                <MenuItem Header="_Content Filter..." Click="ContentFilterMenuItem_Click" InputGestureText="Ctrl+Shift+F"/>
                 <MenuItem Header="_Filename Filter..." Click="FilenameFilterMenuItem_Click" InputGestureText="Ctrl+Alt+F"/>
                 <MenuItem Header="_Clear Filters" Command="{Binding ClearFiltersCommand}" InputGestureText="Esc"/>
                 <Separator/>

--- a/ContextCreator/MainWindow.xaml.cs
+++ b/ContextCreator/MainWindow.xaml.cs
@@ -47,11 +47,12 @@ namespace ContextCreator
             AddKeyBinding(Key.I, ModifierKeys.Control, _viewModel.InvertSelectionCommand);
             AddKeyBinding(Key.T, ModifierKeys.Control, _viewModel.EstimateTokenCountCommand);
             AddKeyBinding(Key.Escape, ModifierKeys.None, _viewModel.ClearFiltersCommand);
+            AddKeyBinding(Key.F, ModifierKeys.Control, _viewModel.ConsolidateFilesCommand);
             
             // Filter commands
             var contentFilterCommand = new RoutedCommand();
             CommandBindings.Add(new CommandBinding(contentFilterCommand, (s, e) => ContentFilterMenuItem_Click(this, new RoutedEventArgs())));
-            AddKeyBinding(Key.F, ModifierKeys.Control, contentFilterCommand);
+            AddKeyBinding(Key.F, ModifierKeys.Control | ModifierKeys.Shift, contentFilterCommand);
             
             var filenameFilterCommand = new RoutedCommand();
             CommandBindings.Add(new CommandBinding(filenameFilterCommand, (s, e) => FilenameFilterMenuItem_Click(this, new RoutedEventArgs())));


### PR DESCRIPTION
This PR adds a new feature that allows users to consolidate selected files from different folders into a single target folder. 

## Changes:
- Added a new menu item "Consolidate Files to Single Folder..." under the File menu
- Implemented `ConsolidateFilesCommand` and the corresponding `ExecuteConsolidateFiles()` method
- Updated keyboard shortcuts to avoid conflicts (Content Filter now uses Ctrl+Shift+F)
- The feature handles filename conflicts by adding a numerical suffix

## How it works:
When the user selects the "Consolidate Files to Single Folder..." option:
1. They're prompted to select a destination folder
2. A new folder called "ConsolidatedFiles" is created at that location
3. All selected files are copied to this folder (with name conflict resolution)
4. The user is informed of the result and given the option to open the new folder

This feature makes it easier to create simple context packages for LLMs without preserving the original directory structure.